### PR TITLE
Add task to "hardhat node" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "tslint --config tslint.json --project tsconfig.json",
     "test": "mocha -t 300000 --exit --recursive 'test/**/*.test.ts'",
     "build": "tsc",
-    "prepublish": "rm -rf dist && yarn build",
+    "prepublish": "rimraf dist && yarn build",
     "watch": "tsc -w",
     "start": "tsc -w"
   },
@@ -48,6 +48,7 @@
     "hardhat-gas-reporter": "^1.0.8",
     "mocha": "^7.1.2",
     "prettier": "2.0.5",
+    "rimraf": "^3.0.2",
     "solidity-coverage": "^0.7.21",
     "ts-node": "^10.7.0",
     "tslint": "^5.16.0",

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,3 +1,4 @@
 import "./decode";
 import "./test";
 import "./trace";
+import "./node";

--- a/src/tasks/node.ts
+++ b/src/tasks/node.ts
@@ -1,0 +1,15 @@
+import { TASK_NODE } from "hardhat/builtin-tasks/task-names";
+import { task } from "hardhat/config";
+
+import { addCliParams, applyCliArgsToTracer } from "../utils";
+import { wrapHardhatProvider } from "../wrapper";
+
+addCliParams(task(TASK_NODE, "Run hardhat node")).setAction(
+  async (args, hre, runSuper) => {
+    applyCliArgsToTracer(args, hre);
+
+    wrapHardhatProvider(hre);
+
+    return runSuper(args);
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,13 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
When call "hardhat node --fulltrace", throwed error "Error HH305: Unrecognized param --fulltrace"
Added a task to enable support for these flags to call "hardhat node"
I also had to fix the npm script, since rm -rf is not cross-platform

Use case:
hardhat node --fulltrace
other terminal
hardhat run ./script_path.ts --network localhost