### PR TITLE
Add `tracer_lastTrace` method to JSON-RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ const callItem = trace1.top?.children?.[0].children?.[0] as CallItem;
 const gasUsed = callItem.params.gasUsed!;
 ```
 
+If you are running `npx hardhat node --trace`, then you can also access last trace using the rpc call `tracer_lastTrace`.
+
 ### Register `--trace` option to custom tasks
 
 ```ts

--- a/src/tasks/node.ts
+++ b/src/tasks/node.ts
@@ -1,34 +1,41 @@
-import { EIP1193Provider, HardhatRuntimeEnvironment, RequestArguments } from "hardhat/types";
-import { ProviderLike } from "../types";
-import { runTask, createTracerTask } from "../utils";
-import { ProviderWrapper } from "hardhat/internal/core/providers/wrapper";
-import { wrapProvider } from "../wrapper";
-import { subtask } from "hardhat/config";
 import { TASK_NODE_GET_PROVIDER } from "hardhat/builtin-tasks/task-names";
-import { addRecorder } from "../extend/hre";
+import { subtask } from "hardhat/config";
+import { ProviderWrapper } from "hardhat/internal/core/providers/wrapper";
+import {
+  EIP1193Provider,
+  HardhatRuntimeEnvironment,
+  RequestArguments,
+} from "hardhat/types";
 
+import { addRecorder } from "../extend/hre";
+import { ProviderLike } from "../types";
+import { createTracerTask, runTask } from "../utils";
+import { wrapProvider } from "../wrapper";
 
 createTracerTask("node").setAction(runTask);
 
-subtask(TASK_NODE_GET_PROVIDER).setAction(
-    async (args, hre, runSuper) => {
-        const provider = await runSuper(args);
-        wrapProvider(hre, new RpcWrapper(hre, provider));
-        addRecorder(hre);
-        return hre.network.provider
-      }
-)
+subtask(TASK_NODE_GET_PROVIDER).setAction(async (args, hre, runSuper) => {
+  const provider = await runSuper(args);
+  wrapProvider(hre, new RpcWrapper(hre, provider));
+  addRecorder(hre).catch(console.error);
+  return hre.network.provider;
+});
 
 class RpcWrapper extends ProviderWrapper {
-    constructor(public hre: HardhatRuntimeEnvironment, public provider: ProviderLike) {
-      super((provider as unknown) as EIP1193Provider);
-    }
+  constructor(
+    public hre: HardhatRuntimeEnvironment,
+    public provider: ProviderLike
+  ) {
+    super((provider as unknown) as EIP1193Provider);
+  }
 
-    public async request({method, params}: RequestArguments): Promise<unknown> {
-        if(method === "tracer_lastTrace") {
-            let trace = this.hre.tracer.lastTrace();
-            return JSON.parse(JSON.stringify(trace, (k, v) => (k === "parent") ? undefined : v));
-        }
-        return await this.provider.send(method, params as any[]);
+  public async request({ method, params }: RequestArguments): Promise<unknown> {
+    if (method === "tracer_lastTrace") {
+      const trace = this.hre.tracer.lastTrace();
+      return JSON.parse(
+        JSON.stringify(trace, (k, v) => (k === "parent" ? undefined : v))
+      );
     }
+    return this.provider.send(method, params as any[]);
+  }
 }

--- a/src/tasks/node.ts
+++ b/src/tasks/node.ts
@@ -1,3 +1,34 @@
-import { registerTask } from "../utils";
+import { EIP1193Provider, HardhatRuntimeEnvironment, RequestArguments } from "hardhat/types";
+import { ProviderLike } from "../types";
+import { runTask, createTracerTask } from "../utils";
+import { ProviderWrapper } from "hardhat/internal/core/providers/wrapper";
+import { wrapProvider } from "../wrapper";
+import { subtask } from "hardhat/config";
+import { TASK_NODE_GET_PROVIDER } from "hardhat/builtin-tasks/task-names";
+import { addRecorder } from "../extend/hre";
 
-registerTask("node");
+
+createTracerTask("node").setAction(runTask);
+
+subtask(TASK_NODE_GET_PROVIDER).setAction(
+    async (args, hre, runSuper) => {
+        const provider = await runSuper(args);
+        wrapProvider(hre, new RpcWrapper(hre, provider));
+        addRecorder(hre);
+        return hre.network.provider
+      }
+)
+
+class RpcWrapper extends ProviderWrapper {
+    constructor(public hre: HardhatRuntimeEnvironment, public provider: ProviderLike) {
+      super((provider as unknown) as EIP1193Provider);
+    }
+
+    public async request({method, params}: RequestArguments): Promise<unknown> {
+        if(method === "tracer_lastTrace") {
+            let trace = this.hre.tracer.lastTrace();
+            return JSON.parse(JSON.stringify(trace, (k, v) => (k === "parent") ? undefined : v));
+        }
+        return await this.provider.send(method, params as any[]);
+    }
+}

--- a/src/utils/task-helpers.ts
+++ b/src/utils/task-helpers.ts
@@ -21,7 +21,11 @@ export function createTracerTask(taskName: string) {
   return addCliParams(task(taskName, `Run hardhat: ${taskName}`));
 }
 
-export async function runTask(args: any, hre: HardhatRuntimeEnvironment, runSuper: any) {
+export async function runTask(
+  args: any,
+  hre: HardhatRuntimeEnvironment,
+  runSuper: any
+) {
   applyCliArgsToTracer(args, hre);
   return runSuper(args);
 }

--- a/src/utils/task-helpers.ts
+++ b/src/utils/task-helpers.ts
@@ -9,15 +9,21 @@ import { wrapHardhatProvider } from "../wrapper";
 import { checkIfOpcodesAreValid } from "./check-opcodes";
 
 export function registerTask(taskName: string) {
-  return addCliParams(task(taskName, `Run hardhat: ${taskName}`)).setAction(
-    async (args, hre, runSuper) => {
-      applyCliArgsToTracer(args, hre);
-
+  return createTracerTask(taskName).setAction(
+    (args: any, hre: HardhatRuntimeEnvironment, runSuper: any) => {
       wrapHardhatProvider(hre);
-
-      return runSuper(args);
+      return runTask(args, hre, runSuper);
     }
   );
+}
+
+export function createTracerTask(taskName: string) {
+  return addCliParams(task(taskName, `Run hardhat: ${taskName}`));
+}
+
+export async function runTask(args: any, hre: HardhatRuntimeEnvironment, runSuper: any) {
+  applyCliArgsToTracer(args, hre);
+  return runSuper(args);
 }
 
 export function addCliParams(_task: ConfigurableTaskDefinition) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -104,18 +104,21 @@ class TracerWrapper extends ProviderWrapper {
  * @param hre: HardhatRuntimeEnvironment - required to get access to contract artifacts and tracer env
  */
 export function wrapHardhatProvider(hre: HardhatRuntimeEnvironment) {
+  wrapProvider(hre, new TracerWrapper({
+    artifacts: hre.artifacts,
+    tracerEnv: hre.tracer,
+    provider: hre.network.provider,
+  }));
+}
+
+export function wrapProvider(hre: HardhatRuntimeEnvironment, wrapper: ProviderWrapper) {
   // do not wrap if already wrapped
   if (isTracerAlreadyWrappedInHreProvider(hre)) {
     return;
   }
 
-  const tracerProvider = new TracerWrapper({
-    artifacts: hre.artifacts,
-    tracerEnv: hre.tracer,
-    provider: hre.network.provider,
-  });
   const compatibleProvider = new BackwardsCompatibilityProviderAdapter(
-    tracerProvider
+    wrapper
   );
   hre.network.provider = compatibleProvider;
 }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -104,22 +104,26 @@ class TracerWrapper extends ProviderWrapper {
  * @param hre: HardhatRuntimeEnvironment - required to get access to contract artifacts and tracer env
  */
 export function wrapHardhatProvider(hre: HardhatRuntimeEnvironment) {
-  wrapProvider(hre, new TracerWrapper({
-    artifacts: hre.artifacts,
-    tracerEnv: hre.tracer,
-    provider: hre.network.provider,
-  }));
+  wrapProvider(
+    hre,
+    new TracerWrapper({
+      artifacts: hre.artifacts,
+      tracerEnv: hre.tracer,
+      provider: hre.network.provider,
+    })
+  );
 }
 
-export function wrapProvider(hre: HardhatRuntimeEnvironment, wrapper: ProviderWrapper) {
+export function wrapProvider(
+  hre: HardhatRuntimeEnvironment,
+  wrapper: ProviderWrapper
+) {
   // do not wrap if already wrapped
   if (isTracerAlreadyWrappedInHreProvider(hre)) {
     return;
   }
 
-  const compatibleProvider = new BackwardsCompatibilityProviderAdapter(
-    wrapper
-  );
+  const compatibleProvider = new BackwardsCompatibilityProviderAdapter(wrapper);
   hre.network.provider = compatibleProvider;
 }
 

--- a/test/fixture-projects/hardhat-project/contracts/Hello.sol
+++ b/test/fixture-projects/hardhat-project/contracts/Hello.sol
@@ -54,7 +54,7 @@ contract Hello {
     revert("hello");
   }
 
-  function hit(Person memory person, uint256 time) external payable {
+  function hit(Person memory person, uint256 time) external payable returns (uint) {
     Child c = new Child(address(0));
     emit WhatsUp(c.hi());
     this.dm();
@@ -64,6 +64,7 @@ contract Hello {
     );
     emit WhatsUp(c.hi());
     // selfdestruct(payable(0));
+    return time;
   }
 
   function crash() external {

--- a/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -13,8 +13,12 @@ const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
 
   networks: {
+    hardhat: {
+      saveDeployments: false,
+    },
     localhost: {
       url: "http://localhost:8545",
+      saveDeployments: false,
     },
     mainnet: {
       chainId: 1,

--- a/test/fixture-projects/hardhat-project/test/Hello.test.ts
+++ b/test/fixture-projects/hardhat-project/test/Hello.test.ts
@@ -88,10 +88,18 @@ describe("Hello", () => {
     );
 
     expect(hre.tracer.lastTrace()).to.have.messageCall(
-      await contract.populateTransaction.getData(),
+      await contract.populateTransaction.hit(
+        {
+          name: "hello",
+          age: 23,
+          props: { id: 12, name: "yello", age: 99 },
+        },
+        1234,
+        { value: parseEther("1") }
+      ),
       {
-        returnData: ethers.utils.defaultAbiCoder.encode(["uint"], ["1234"]),
-        from: contract.address,
+        // returnData: ethers.utils.defaultAbiCoder.encode(["uint"], ["1234"]),
+        from: await contract.signer.getAddress(),
       }
     );
   });

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,9 +1,9 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { assert, expect } from "chai";
 import { config } from "dotenv";
+import { TASK_NODE_GET_PROVIDER } from "hardhat/builtin-tasks/task-names";
 
 import { useEnvironment } from "./helpers";
-import { TASK_NODE_GET_PROVIDER } from "hardhat/builtin-tasks/task-names";
 config();
 
 const ALCHEMY = process.env.ALCHEMY;
@@ -148,7 +148,7 @@ describe("Hardhat Runtime Environment extension", function () {
     it("works", async function () {
       await this.hre.run("compile");
 
-      let provider = await this.hre.run(TASK_NODE_GET_PROVIDER, {
+      const provider = await this.hre.run(TASK_NODE_GET_PROVIDER, {
         "no-deploy": true,
         silent: true,
       });

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,9 +1,9 @@
 // tslint:disable-next-line no-implicit-dependencies
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import { config } from "dotenv";
-import path from "path";
 
 import { useEnvironment } from "./helpers";
+import { TASK_NODE_GET_PROVIDER } from "hardhat/builtin-tasks/task-names";
 config();
 
 const ALCHEMY = process.env.ALCHEMY;
@@ -139,6 +139,30 @@ describe("Hardhat Runtime Environment extension", function () {
           "0xce4c18de00000000000000000000000000000000000000000000000000000000a913a04f",
         rpc: "https://arb-mainnet.g.alchemy.com/v2/" + ALCHEMY,
       });
+    });
+  });
+
+  describe("RPC call tracer_lastTrace", function () {
+    useEnvironment("hardhat-project");
+
+    it("works", async function () {
+      await this.hre.run("compile");
+
+      let provider = await this.hre.run(TASK_NODE_GET_PROVIDER, {
+        "no-deploy": true,
+        silent: true,
+      });
+
+      await this.hre.run("test");
+
+      const lastTraceRpc = await provider.send("tracer_lastTrace");
+      const lastTraceApi = await this.hre.tracer.lastTrace();
+
+      // patch for deep equal
+      lastTraceRpc.parent = undefined;
+      lastTraceRpc.top.params.exception = undefined;
+
+      expect(lastTraceRpc).to.deep.equal(lastTraceApi);
     });
   });
 


### PR DESCRIPTION
Resolves #62.

The PR implements `tracer_lastTrace` RPC method to retrieve last trace via JSON-RPC endpoint from a standalone hardhat node.