### PR TITLE
Make gaslimit and gasprice usable in tracecall

### DIFF
--- a/src/tasks/tracecall.ts
+++ b/src/tasks/tracecall.ts
@@ -12,8 +12,8 @@ addCliParams(task("tracecall", "Traces a call"))
   .addParam("to", "destination address")
   .addOptionalParam("data", "input call data")
   .addOptionalParam("value", "value to send")
-  .addOptionalParam("gasLimit", "gas limit")
-  .addOptionalParam("gasPrice", "gas price")
+  .addOptionalParam("gaslimit", "gas limit")
+  .addOptionalParam("gasprice", "gas price")
   .addOptionalParam("blocknumber", "block number")
   .addOptionalParam("from", "from address")
   .addOptionalParam("rpc", "archive node")
@@ -88,8 +88,8 @@ addCliParams(task("tracecall", "Traces a call"))
         to: args.to,
         data: args.data,
         value: args.value,
-        gasLimit: args.gasLimit,
-        gasPrice: args.gasPrice,
+        gasLimit: args.gaslimit,
+        gasPrice: args.gasprice,
         from: args.from,
       });
       console.log("eth_call result:", result);


### PR DESCRIPTION
As it stands, the `gasLimit` and `gasPrice` parameters (albeit undocumented?) are not usable. This is because `hardhat` [enforces command line parameters to be lowercase](https://github.com/NomicFoundation/hardhat/blob/739d593d46123c6584de10c7bc5fce10bae4b9e2/packages/hardhat-core/src/internal/cli/ArgumentsParser.ts#L30). When trying to use latest `hardhat-tracer`, and passing `--gasLimit` to `tracecall`:

```
Error HH310: Invalid param --gasLimit. Command line params must be lowercase.
```

But then when trying to make it lowercase:

```
Error HH305: Unrecognized param --gaslimit
```

This PR makes them lowercase. It also appears to work - when tracing a call with `--gaslimit` and providing much less gas than it needs, at the end of my call I get:

```
   [EXCEPTION] EvmError(reason: "OUT_OF_GAS")
```

as I would expect.

